### PR TITLE
Flatten the WebRender API to allow us to use shared memory to transfer display lists.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use display_list::DisplayListBuilder;
+use display_list::{AuxiliaryLists, BuiltDisplayList};
 use euclid::{Point2D, Size2D};
 use ipc_channel::ipc::{self, IpcSender};
 use stacking_context::StackingContext;
@@ -24,10 +24,15 @@ pub enum ApiMsg {
     AddNativeFont(FontKey, NativeFontHandle),
     AddImage(ImageKey, u32, u32, ImageFormat, Vec<u8>),
     UpdateImage(ImageKey, u32, u32, ImageFormat, Vec<u8>),
-    AddDisplayList(DisplayListId, PipelineId, Epoch, DisplayListBuilder),
+    AddDisplayList(DisplayListId, PipelineId, Epoch, BuiltDisplayList),
     AddStackingContext(StackingContextId, PipelineId, Epoch, StackingContext),
     CloneApi(IpcSender<IdNamespace>),
-    SetRootStackingContext(StackingContextId, ColorF, Epoch, PipelineId, Size2D<f32>),
+    SetRootStackingContext(StackingContextId,
+                           ColorF,
+                           Epoch,
+                           PipelineId,
+                           Size2D<f32>,
+                           AuxiliaryLists),
     SetRootPipeline(PipelineId),
     Scroll(Point2D<f32>, Point2D<f32>),
     TranslatePointToLayerSpace(Point2D<f32>, IpcSender<Point2D<f32>>),
@@ -112,7 +117,7 @@ impl RenderApi {
     }
 
     pub fn add_display_list(&self,
-                            display_list: DisplayListBuilder,
+                            display_list: BuiltDisplayList,
                             stacking_context: &mut StackingContext,
                             pipeline_id: PipelineId,
                             epoch: Epoch) -> Option<DisplayListId> {
@@ -149,12 +154,14 @@ impl RenderApi {
                                      background_color: ColorF,
                                      epoch: Epoch,
                                      pipeline_id: PipelineId,
-                                     viewport_size: Size2D<f32>) {
+                                     viewport_size: Size2D<f32>,
+                                     auxiliary_lists: AuxiliaryLists) {
         let msg = ApiMsg::SetRootStackingContext(stacking_context_id,
                                                  background_color,
                                                  epoch,
                                                  pipeline_id,
-                                                 viewport_size);
+                                                 viewport_size,
+                                                 auxiliary_lists);
         self.tx.send(msg).unwrap();
     }
 

--- a/src/display_item.rs
+++ b/src/display_item.rs
@@ -3,12 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
-use types::{ClipRegion, ColorF, GlyphInstance, FontKey, ImageKey, BorderSide};
-use types::{GradientStop, BorderRadius, BoxShadowClipMode, ImageRendering};
+use display_list::ItemRange;
+use types::{ClipRegion, ColorF, FontKey, ImageKey, BorderSide};
+use types::{BorderRadius, BoxShadowClipMode, ImageRendering};
 use webgl::{WebGLContextId};
 use euclid::{Point2D, Rect, Size2D};
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BorderDisplayItem {
     pub left: BorderSide,
     pub right: BorderSide,
@@ -39,7 +40,7 @@ impl BorderDisplayItem {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BoxShadowDisplayItem {
     pub box_bounds: Rect<f32>,
     pub offset: Point2D<f32>,
@@ -50,40 +51,40 @@ pub struct BoxShadowDisplayItem {
     pub clip_mode: BoxShadowClipMode,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GradientDisplayItem {
     pub start_point: Point2D<f32>,
     pub end_point: Point2D<f32>,
-    pub stops: Vec<GradientStop>,
+    pub stops: ItemRange,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ImageDisplayItem {
     pub image_key: ImageKey,
     pub stretch_size: Size2D<f32>,
     pub image_rendering: ImageRendering,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct WebGLDisplayItem {
     pub context_id: WebGLContextId,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RectangleDisplayItem {
     pub color: ColorF,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TextDisplayItem {
-    pub glyphs: Vec<GlyphInstance>,
+    pub glyphs: ItemRange,
     pub font_key: FontKey,
     pub size: Au,
     pub color: ColorF,
     pub blur_radius: Au,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum SpecificDisplayItem {
     Rectangle(RectangleDisplayItem),
     Text(TextDisplayItem),
@@ -94,7 +95,7 @@ pub enum SpecificDisplayItem {
     Gradient(GradientDisplayItem),
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DisplayItem {
     pub item: SpecificDisplayItem,
     pub rect: Rect<f32>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,9 @@ mod types;
 mod webgl;
 
 pub use api::{ApiMsg, IdNamespace, ResourceId, RenderApi, RenderApiSender};
-pub use display_list::{DisplayListBuilder, DisplayListItem};
-pub use display_list::{SpecificDisplayListItem, IframeInfo};
+pub use display_list::{AuxiliaryLists, AuxiliaryListsBuilder, BuiltDisplayList};
+pub use display_list::{DisplayListBuilder, DisplayListItem, IframeInfo, ItemRange};
+pub use display_list::{SpecificDisplayListItem};
 pub use display_item::{DisplayItem, SpecificDisplayItem, ImageDisplayItem};
 pub use display_item::{BorderDisplayItem, GradientDisplayItem, RectangleDisplayItem};
 pub use stacking_context::StackingContext;

--- a/src/stacking_context.rs
+++ b/src/stacking_context.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use display_list::{AuxiliaryListsBuilder, ItemRange};
 use euclid::{Matrix4, Rect};
 use types::{DisplayListId, FilterOp, MixBlendMode, ScrollLayerId, ScrollPolicy};
 
@@ -17,7 +18,7 @@ pub struct StackingContext {
     pub perspective: Matrix4,
     pub establishes_3d_context: bool,
     pub mix_blend_mode: MixBlendMode,
-    pub filters: Vec<FilterOp>,
+    pub filters: ItemRange,
     pub has_stacking_contexts: bool,
 }
 
@@ -31,7 +32,8 @@ impl StackingContext {
                perspective: &Matrix4,
                establishes_3d_context: bool,
                mix_blend_mode: MixBlendMode,
-               filters: Vec<FilterOp>)
+               filters: Vec<FilterOp>,
+               auxiliary_lists_builder: &mut AuxiliaryListsBuilder)
                -> StackingContext {
         StackingContext {
             scroll_layer_id: scroll_layer_id,
@@ -44,7 +46,7 @@ impl StackingContext {
             perspective: perspective.clone(),
             establishes_3d_context: establishes_3d_context,
             mix_blend_mode: mix_blend_mode,
-            filters: filters,
+            filters: auxiliary_lists_builder.add_filters(&filters),
             has_stacking_contexts: false,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
+use display_list::{AuxiliaryListsBuilder, ItemRange};
 use euclid::{Rect, Size2D};
 
 #[cfg(target_os="macos")]
@@ -36,7 +37,7 @@ impl BorderRadius {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BorderSide {
     pub width: f32,
     pub color: ColorF,
@@ -64,17 +65,20 @@ pub enum BoxShadowClipMode {
     Inset,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ClipRegion {
     pub main: Rect<f32>,
-    pub complex: Vec<ComplexClipRegion>,
+    pub complex: ItemRange,
 }
 
 impl ClipRegion {
-    pub fn new(rect: Rect<f32>, complex: Vec<ComplexClipRegion>) -> ClipRegion {
+    pub fn new(rect: &Rect<f32>,
+               complex: Vec<ComplexClipRegion>,
+               auxiliary_lists_builder: &mut AuxiliaryListsBuilder)
+               -> ClipRegion {
         ClipRegion {
-            main: rect,
-            complex: complex,
+            main: *rect,
+            complex: auxiliary_lists_builder.add_complex_clip_regions(&complex),
         }
     }
 }
@@ -130,7 +134,7 @@ pub struct StackingContextId(pub u32, pub u32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct DisplayListId(pub u32, pub u32);
 
-#[derive(Serialize, Deserialize)]
+#[derive(Copy, Clone, Serialize, Deserialize)]
 pub enum DisplayListMode {
     Default,
     PseudoFloat,
@@ -162,14 +166,14 @@ impl FontKey {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GlyphInstance {
     pub index: u32,
     pub x: f32,
     pub y: f32,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GradientStop {
     pub offset: f32,
     pub color: ColorF,


### PR DESCRIPTION
Improves performance significantly.

r? @glennw
