### PR TITLE
Webgl limits

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -11,7 +11,7 @@ use std::cell::Cell;
 use types::{ColorF, DisplayListId, Epoch, FontKey, StackingContextId};
 use types::{ImageKey, ImageFormat, NativeFontHandle, PipelineId};
 use webgl::{WebGLContextId, WebGLCommand};
-use offscreen_gl_context::GLContextAttributes;
+use offscreen_gl_context::{GLContextAttributes, GLLimits};
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct IdNamespace(pub u32);
@@ -57,7 +57,7 @@ pub enum ApiMsg {
     Scroll(Point2D<f32>, Point2D<f32>, ScrollEventPhase),
     TickScrollingBounce,
     TranslatePointToLayerSpace(Point2D<f32>, IpcSender<Point2D<f32>>),
-    RequestWebGLContext(Size2D<i32>, GLContextAttributes, IpcSender<Result<WebGLContextId, String>>),
+    RequestWebGLContext(Size2D<i32>, GLContextAttributes, IpcSender<Result<(WebGLContextId, GLLimits), String>>),
     WebGLCommand(WebGLContextId, WebGLCommand),
 }
 
@@ -212,7 +212,7 @@ impl RenderApi {
     }
 
     pub fn request_webgl_context(&self, size: &Size2D<i32>, attributes: GLContextAttributes)
-                                 -> Result<WebGLContextId, String> {
+                                 -> Result<(WebGLContextId, GLLimits), String> {
         let (tx, rx) = ipc::channel().unwrap();
         let msg = ApiMsg::RequestWebGLContext(*size, attributes, tx);
         self.api_sender.send(msg).unwrap();

--- a/src/webgl.rs
+++ b/src/webgl.rs
@@ -321,7 +321,7 @@ impl WebGLCommand {
             WebGLCommand::VertexAttrib(attrib_id, x, y, z, w) =>
                 gl::vertex_attrib_4f(attrib_id, x, y, z, w),
             WebGLCommand::VertexAttribPointer2f(attrib_id, size, normalized, stride, offset) =>
-                gl::vertex_attrib_pointer_f32(attrib_id, size, normalized, stride, offset as u32),
+                gl::vertex_attrib_pointer_f32(attrib_id, size, normalized, stride, offset),
             WebGLCommand::Viewport(x, y, width, height) =>
                 gl::viewport(x, y, width, height),
             WebGLCommand::TexImage2D(target, level, internal, width, height, format, data_type, data) =>


### PR DESCRIPTION
Return the GLLimits structure from the `RequestWebGLContext` API message.

This allows us to keep a lot of calls that would require validation here asynchronous.

See https://github.com/servo/servo/pull/10224

r? @glennw 
