### PR TITLE
Remove the concept of StackingLevels

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,5 +39,5 @@ pub use types::{ColorF, ClipRegion, ComplexClipRegion};
 pub use types::{DisplayListId, DisplayListMode, ImageRendering};
 pub use types::{Epoch, FilterOp, FontKey, GlyphInstance, GradientStop};
 pub use types::{ImageFormat, ImageKey, MixBlendMode, PipelineId, RenderNotifier};
-pub use types::{ScrollLayerId, ScrollPolicy, StackingLevel, StackingContextId, ScrollLayerInfo};
+pub use types::{ScrollLayerId, ScrollPolicy, StackingContextId, ScrollLayerInfo};
 pub use webgl::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -274,13 +274,3 @@ pub enum ScrollPolicy {
     Scrollable,
     Fixed,
 }
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub enum StackingLevel {
-    BackgroundAndBorders,
-    BlockBackgroundAndBorders,
-    Floats,
-    Content,
-    PositionedContent,
-    Outlines,
-}


### PR DESCRIPTION
Servo now sorts the display list before passing it to WebRender, so we
don't need to have the concept of StackingLevels. Instead we can just
keep a list of items and StackingContexts.
