### PR TITLE
Update Rust version in travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - nightly
-  - nightly-2016-04-06 # Should be kept in sync with Servo.
+  - nightly-2016-04-11 # Should be kept in sync with Servo.
 matrix:
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
Servo's rust version has changed, so we must pin travis to the new
version.
