### PR TITLE
Make built display lists and auxiliary lists more flexible to avoid copies.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ mod webgl;
 
 pub use api::{ApiMsg, IdNamespace, ResourceId, RenderApi, RenderApiSender, ScrollEventPhase};
 pub use display_list::{AuxiliaryLists, AuxiliaryListsBuilder, BuiltDisplayList};
-pub use display_list::{DisplayListBuilder, DisplayListItem, IframeInfo, ItemRange};
-pub use display_list::{SpecificDisplayListItem};
+pub use display_list::{BuiltDisplayListRef, DisplayListBuilder, DisplayListItem, IframeInfo};
+pub use display_list::{ItemRange, SpecificDisplayListItem};
 pub use display_item::{DisplayItem, SpecificDisplayItem, ImageDisplayItem};
 pub use display_item::{BorderDisplayItem, GradientDisplayItem, RectangleDisplayItem};
 pub use stacking_context::StackingContext;


### PR DESCRIPTION
There are two changes here:
- `BuiltDisplayListRef` is a display list that references a buffer
  instead of owning it.
- `AuxiliaryLists` can now reference a subset of a vector.

This allows us to avoid several copies of the underlying buffer, which
improves performance.

r? @glennw
