### PR TITLE
fix is_shader and is_texture commands

### DIFF
--- a/src/webgl.rs
+++ b/src/webgl.rs
@@ -112,8 +112,8 @@ pub enum WebGLCommand {
     StencilOp(u32, u32, u32),
     StencilOpSeparate(u32, u32, u32, u32),
     Hint(u32, u32),
-    IsShader(u32),
-    IsTexture(u32),
+    IsShader(u32, IpcSender<bool>),
+    IsTexture(u32, IpcSender<bool>),
     LineWidth(f32),
     PixelStorei(u32, i32),
     LinkProgram(u32),
@@ -327,10 +327,10 @@ impl WebGLCommand {
                 gl::enable_vertex_attrib_array(attrib_id),
             WebGLCommand::Hint(name, val) =>
                 gl::hint(name, val),
-            WebGLCommand::IsShader(shader) =>
-                gl::is_shader(shader),
-            WebGLCommand::IsTexture(texture) =>
-                gl::is_texture(texture),
+            WebGLCommand::IsShader(shader, chan) =>
+                Self::is_shader(shader, chan),
+            WebGLCommand::IsTexture(texture, chan) =>
+                Self::is_texture(texture, chan),
             WebGLCommand::LineWidth(width) =>
                 gl::line_width(width),
             WebGLCommand::PixelStorei(name, val) =>
@@ -790,6 +790,18 @@ impl WebGLCommand {
             Some(unsafe { NonZero::new(shader) })
         };
         chan.send(shader).unwrap();
+    }
+
+    fn is_shader(shader: u32, chan: IpcSender<bool>) {
+        let result = gl::is_shader(shader);
+        let result = result == 1;
+        chan.send(result).unwrap();
+    }
+
+    fn is_texture(texture: u32, chan: IpcSender<bool>) {
+        let result = gl::is_texture(texture);
+        let result = result == 1;
+        chan.send(result).unwrap();
     }
 
     #[inline]


### PR DESCRIPTION
This pr is a fix to the error I introduced in #49 
Successfully built with cargo build and in servo with ./mach build 
In the previous pr I just built it with ./mach build in servo but did not update cargo.lock. I am sorry about this.
