### PR TITLE
Use UUIDs for PipelineIds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ heapsize = "0.3.6"
 offscreen_gl_context = {version = "0.1.9", features = ["serde_serialization"]}
 serde = "0.7.11"
 serde_macros = {version = "0.7.11", optional = true}
+uuid = {version = "0.2", features = ["v4"]}
 
 [target.x86_64-apple-darwin.dependencies]
 core-graphics = ">=0.2, <0.4"

--- a/src/api.rs
+++ b/src/api.rs
@@ -161,14 +161,6 @@ impl RenderApi {
         self.api_sender.send(msg).unwrap();
     }
 
-    pub fn translate_point_to_layer_space(&self, point: &Point2D<f32>)
-                                          -> (Point2D<f32>, PipelineId) {
-        let (tx, rx) = ipc::channel().unwrap();
-        let msg = ApiMsg::TranslatePointToLayerSpace(*point, tx);
-        self.api_sender.send(msg).unwrap();
-        rx.recv().unwrap()
-    }
-
     pub fn get_scroll_layer_state(&self) -> Vec<ScrollLayerState> {
         let (tx, rx) = ipc::channel().unwrap();
         let msg = ApiMsg::GetScrollLayerState(tx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ extern crate heapsize;
 extern crate ipc_channel;
 extern crate offscreen_gl_context;
 extern crate serde;
+extern crate uuid;
 
 #[cfg(target_os = "macos")] extern crate core_graphics;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,6 +11,7 @@ use core::nonzero::NonZero;
 use euclid::{Matrix4, Point2D, Rect, Size2D};
 use ipc_channel::ipc::{IpcBytesSender, IpcSender};
 use offscreen_gl_context::{GLContextAttributes, GLLimits};
+use uuid::Uuid;
 
 #[cfg(target_os = "macos")] use core_graphics::font::CGFont;
 
@@ -44,7 +45,6 @@ pub enum ApiMsg {
     SetRootPipeline(PipelineId),
     Scroll(Point2D<f32>, Point2D<f32>, ScrollEventPhase),
     TickScrollingBounce,
-    TranslatePointToLayerSpace(Point2D<f32>, IpcSender<(Point2D<f32>, PipelineId)>),
     GetScrollLayerState(IpcSender<Vec<ScrollLayerState>>),
     RequestWebGLContext(Size2D<i32>, GLContextAttributes, IpcSender<Result<(WebGLContextId, GLLimits), String>>),
     WebGLCommand(WebGLContextId, WebGLCommand),
@@ -313,7 +313,9 @@ pub type NativeFontHandle = CGFont;
 pub struct NativeFontHandle;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct PipelineId(pub u32, pub u32);
+pub struct PipelineId {
+    pub id: Uuid,
+}
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct RectangleDisplayItem {


### PR DESCRIPTION
This change is [being made in Servo](https://github.com/servo/servo/pull/10808) for security purposes;
this commit updates the definition to match for Webrender.
See the Servo repo for the reasoning behind this change.

Additionally, remove the TranslatePointToLayerSpace message
from the API; as of servo/servo#11537 this is no longer used.
Servo now uses a unified code path for mouse events whether
WebRender is in use or not. (Mouse events are always dispatched
to the root pipeline, removing the need to translate into
layer space.
