### PR TITLE
Restore all derivations on WebGLError

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -539,7 +539,7 @@ pub struct WebGLDisplayItem {
     pub context_id: WebGLContextId,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum WebGLError {
     InvalidEnum,
     InvalidOperation,


### PR DESCRIPTION
They went away when I made serde_codegen usable with the crate.
