### PR TITLE
Use wrappers for GL IDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ build = "build.rs"
 
 [features]
 default = ["serde_codegen"]
+nightly = ["euclid/unstable", "serde/nightly"]
 
 [dependencies.ipc-channel]
 git = "https://github.com/servo/ipc-channel"
@@ -15,8 +16,9 @@ app_units = "0.2.5"
 byteorder = "0.5"
 euclid = "0.7.1"
 gleam = "0.2.19"
+heapsize = "0.3.6"
 offscreen_gl_context = {version = "0.1.9", features = ["serde_serialization"]}
-serde = {version = "0.7.11", features = ["nightly"]}
+serde = "0.7.11"
 serde_macros = {version = "0.7.11", optional = true}
 
 [target.x86_64-apple-darwin.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,15 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![cfg_attr(feature = "nightly", feature(nonzero))]
 #![cfg_attr(feature = "serde_macros", feature(custom_derive, plugin))]
 #![cfg_attr(feature = "serde_macros", plugin(serde_macros))]
-#![feature(nonzero)]
 
 extern crate app_units;
 extern crate byteorder;
+#[cfg(feature = "nightly")]
 extern crate core;
 extern crate euclid;
 extern crate gleam;
+extern crate heapsize;
 extern crate ipc_channel;
 extern crate offscreen_gl_context;
 extern crate serde;


### PR DESCRIPTION
These wrappers make the handling of buffers, framebuffers, programs,
renderbuffers, shaders and textures a bit more type-safe and allow
us to make nonzero usage optional.
